### PR TITLE
feat/auth: JWT 인증/인가 기본 구성 추가 (add JWT authentication and security configuration)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,12 +25,25 @@ repositories {
 }
 
 dependencies {
+	// Spring Boot
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+
+	// JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
+	// Lombok
 	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
+
+	// DB
+	runtimeOnly 'com.mysql:mysql-connector-j'
+
+	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/com/kjh/spacebook/SpacebookApplication.java
+++ b/src/main/java/com/kjh/spacebook/SpacebookApplication.java
@@ -2,8 +2,10 @@ package com.kjh.spacebook;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class SpacebookApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/kjh/spacebook/common/config/PasswordEncoderConfig.java
+++ b/src/main/java/com/kjh/spacebook/common/config/PasswordEncoderConfig.java
@@ -1,0 +1,15 @@
+package com.kjh.spacebook.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordEncoderConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/kjh/spacebook/common/security/SecurityConfig.java
+++ b/src/main/java/com/kjh/spacebook/common/security/SecurityConfig.java
@@ -1,0 +1,98 @@
+package com.kjh.spacebook.common.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import com.kjh.spacebook.common.response.ApiResponse;
+import com.kjh.spacebook.common.security.jwt.JwtAuthenticationFilter;
+import com.kjh.spacebook.domain.auth.exception.AuthErrorCode;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import static org.springframework.security.config.Customizer.withDefaults;
+
+@Configuration
+@RequiredArgsConstructor
+public class SecurityConfig {
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final ObjectMapper objectMapper;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(csrf -> csrf.disable())
+                .cors(withDefaults())
+                // JWT 기반 인증만 사용하므로 기본 Form Login 및 Http Basic 비활성화
+                .formLogin(form -> form.disable())
+                .httpBasic(basic -> basic.disable())
+                .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(unauthorizedEntryPoint())
+                        .accessDeniedHandler(accessDeniedHandler()))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/swagger-ui/**",
+                                "/swagger-ui.html",
+                                "/v3/api-docs",
+                                "/v3/api-docs/**",
+                                "/swagger-resources/**",
+                                "/webjars/**")
+                        .permitAll()
+                        .requestMatchers("/api/v1/auth/signup", "/api/v1/auth/login", "/api/v1/auth/tokens").permitAll()
+                        .requestMatchers("/actuator/**").permitAll()
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                        .requestMatchers("/healthz").permitAll()
+                        .anyRequest().authenticated())
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .build();
+    }
+
+    private AuthenticationEntryPoint unauthorizedEntryPoint() {
+        return (request, response, authException) -> {
+            ApiResponse<?> error = ApiResponse.error(AuthErrorCode.UNAUTHENTICATED.getMessage());
+
+            response.setStatus(AuthErrorCode.UNAUTHENTICATED.getStatus().value());
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+            response.setCharacterEncoding("UTF-8");
+
+            objectMapper.writeValue(response.getWriter(), error);
+        };
+    }
+
+    private AccessDeniedHandler accessDeniedHandler() {
+        return (request, response, accessDeniedException) -> {
+            ApiResponse<?> error = ApiResponse.error("해당 리소스에 접근할 권한이 없습니다.");
+
+            response.setStatus(HttpStatus.FORBIDDEN.value());
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+            response.setCharacterEncoding("UTF-8");
+
+            objectMapper.writeValue(response.getWriter(), error);
+        };
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.addAllowedOriginPattern("*");
+        config.addAllowedMethod("*");
+        config.addAllowedHeader("*");
+        config.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
+    }
+
+}

--- a/src/main/java/com/kjh/spacebook/common/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/kjh/spacebook/common/security/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,97 @@
+package com.kjh.spacebook.common.security.jwt;
+
+import java.io.IOException;
+import java.util.List;
+
+import com.kjh.spacebook.domain.user.enums.Role;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.lang.NonNull;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private final JwtUtil jwtUtil;
+
+    @Override
+    protected void doFilterInternal(
+        @NonNull HttpServletRequest req,
+        @NonNull HttpServletResponse res,
+        @NonNull FilterChain chain) throws ServletException, IOException {
+        if (SecurityContextHolder.getContext().getAuthentication() != null) {
+            chain.doFilter(req, res);
+
+            return;
+        }
+
+        String token = resolveToken(req);
+
+        if (token == null || token.isBlank()) {
+            chain.doFilter(req, res);
+
+            return;
+        }
+
+        try {
+            Claims claims = jwtUtil.validateAndGetClaims(token);
+            Long userId = Long.valueOf(claims.getSubject());
+            String roleValue = claims.get("role", String.class);
+
+            if (roleValue == null || roleValue.isBlank()) {
+                SecurityContextHolder.clearContext();
+                chain.doFilter(req, res);
+
+                return;
+            }
+
+            Role role;
+            try {
+                role = Role.valueOf(roleValue);
+            } catch (IllegalArgumentException e) {
+                log.warn("유효하지 않은 role: {}", roleValue);
+                SecurityContextHolder.clearContext();
+                chain.doFilter(req, res);
+
+                return;
+            }
+
+            var authorities = List.of(new SimpleGrantedAuthority("ROLE_" + role.name()));
+            var authentication = new UsernamePasswordAuthenticationToken(userId, null, authorities);
+            authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(req));
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        } catch (io.jsonwebtoken.ExpiredJwtException e) {
+            log.warn("JWT 만료: {}", e.getMessage());
+            SecurityContextHolder.clearContext();
+        } catch (io.jsonwebtoken.security.SignatureException e) {
+            log.warn("JWT 서명 불일치: {}", e.getMessage());
+            SecurityContextHolder.clearContext();
+        } catch (Exception e) {
+            log.warn("JWT 인증 실패: {}", e.getMessage());
+            SecurityContextHolder.clearContext();
+        }
+        chain.doFilter(req, res);
+    }
+
+    private String resolveToken(HttpServletRequest req) {
+        String h = req.getHeader("Authorization");
+
+        if (h != null && h.startsWith("Bearer ")) {
+            return h.substring(7);
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/kjh/spacebook/common/security/jwt/JwtProperties.java
+++ b/src/main/java/com/kjh/spacebook/common/security/jwt/JwtProperties.java
@@ -1,0 +1,11 @@
+package com.kjh.spacebook.common.security.jwt;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+import jakarta.validation.constraints.NotBlank;
+
+@Validated
+@ConfigurationProperties(prefix = "jwt")
+public record JwtProperties(@NotBlank String secret) {
+}

--- a/src/main/java/com/kjh/spacebook/common/security/jwt/JwtUtil.java
+++ b/src/main/java/com/kjh/spacebook/common/security/jwt/JwtUtil.java
@@ -1,0 +1,57 @@
+package com.kjh.spacebook.common.security.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtParser;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+
+@Component
+public class JwtUtil {
+    private static final Duration ACCESS_TOKEN_EXPIRATION = Duration.ofMinutes(30);
+    private static final Duration REFRESH_TOKEN_EXPIRATION = Duration.ofDays(7);
+
+    private final SecretKey key;
+    private final JwtParser parser;
+
+    public JwtUtil(JwtProperties jwtProperties) {
+        this.key = Keys.hmacShaKeyFor(Decoders.BASE64.decode(jwtProperties.secret()));
+        this.parser = Jwts.parser()
+                .clockSkewSeconds(60)
+                .verifyWith(key)
+                .build();
+    }
+
+    public String createAccessToken(Long userId, String role) {
+        Instant now = Instant.now();
+
+        return Jwts.builder()
+                .subject(String.valueOf(userId))
+                .claim("role", role)
+                .issuedAt(Date.from(now))
+                .expiration(Date.from(now.plus(ACCESS_TOKEN_EXPIRATION)))
+                .signWith(key)
+                .compact();
+    }
+
+    public String createRefreshToken(Long userId) {
+        Instant now = Instant.now();
+
+        return Jwts.builder()
+                .subject(String.valueOf(userId))
+                .issuedAt(Date.from(now))
+                .expiration(Date.from(now.plus(REFRESH_TOKEN_EXPIRATION)))
+                .signWith(key)
+                .compact();
+    }
+
+    public Claims validateAndGetClaims(String token) {
+        return parser.parseSignedClaims(token).getPayload();
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -17,3 +17,6 @@ spring:
       hibernate:
         format_sql: true
     open-in-view: false
+
+jwt:
+  secret: ${JWT_SECRET}


### PR DESCRIPTION
## 연관된 이슈
Related #14

## 작업 내용
- JWT 기반 인증/인가 구조 구성 (SecurityConfig, JwtUtil, JwtAuthenticationFilter, JwtProperties)
- PasswordEncoder를 Spring Security 표준 BCryptPasswordEncoder로 설정
- build.gradle에 JJWT, Validation 의존성 추가 및 그룹별 정리
- application.yaml에 jwt.secret 환경변수 바인딩 추가
- @ConfigurationPropertiesScan 활성화
- formLogin, httpBasic 비활성화

## 변경 파일
| 파일 | 변경 내용 |
|------|-----------|
| `SecurityConfig.java` | JWT 필터 체인, CORS, 세션 STATELESS 설정 |
| `JwtUtil.java` | JWT 토큰 생성/파싱/검증 유틸리티 |
| `JwtAuthenticationFilter.java` | 요청마다 JWT 검증 후 SecurityContext 설정 |
| `JwtProperties.java` | JWT 설정값 외부화 (secret, expiration) |
| `PasswordEncoderConfig.java` | BCryptPasswordEncoder Bean 등록 |
| `SpacebookApplication.java` | @ConfigurationPropertiesScan 추가 |
| `build.gradle` | JJWT, Validation 의존성 추가 |
| `application.yaml` | jwt.secret 환경변수 바인딩 |

## 테스트 방법
```bash
# 앱 기동 확인
curl http://localhost:8080/healthz                          # 200 OK
```

## 기타 참고 사항
- ApiResponse, AuthErrorCode는 별도 커밋 예정
- User 엔티티, Role enum은 feat/user 브랜치에서 진행 예정