### PR TITLE
feat/ai: AI 기반 공간 추천 기능 구현 (add AI-powered space recommendation with Groq API)

### DIFF
--- a/src/main/java/com/kjh/spacebook/common/config/RestTemplateConfig.java
+++ b/src/main/java/com/kjh/spacebook/common/config/RestTemplateConfig.java
@@ -1,0 +1,14 @@
+package com.kjh.spacebook.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/kjh/spacebook/domain/recommendation/controller/RecommendationController.java
+++ b/src/main/java/com/kjh/spacebook/domain/recommendation/controller/RecommendationController.java
@@ -1,0 +1,33 @@
+package com.kjh.spacebook.domain.recommendation.controller;
+
+import com.kjh.spacebook.common.response.ApiResponse;
+import com.kjh.spacebook.domain.recommendation.dto.request.RecommendRequest;
+import com.kjh.spacebook.domain.recommendation.service.RecommendationService;
+import com.kjh.spacebook.domain.space.dto.response.SpaceListResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/recommendations")
+@RequiredArgsConstructor
+public class RecommendationController {
+    private final RecommendationService recommendationService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<List<SpaceListResponse>>> recommend(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody RecommendRequest request
+    ) {
+        List<SpaceListResponse> responses = recommendationService.recommend(request.query());
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(responses));
+    }
+}

--- a/src/main/java/com/kjh/spacebook/domain/recommendation/dto/request/RecommendRequest.java
+++ b/src/main/java/com/kjh/spacebook/domain/recommendation/dto/request/RecommendRequest.java
@@ -1,0 +1,8 @@
+package com.kjh.spacebook.domain.recommendation.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record RecommendRequest(
+        @NotBlank(message = "검색어를 입력해주세요.")
+        String query
+) {}

--- a/src/main/java/com/kjh/spacebook/domain/recommendation/exception/RecommendationErrorCode.java
+++ b/src/main/java/com/kjh/spacebook/domain/recommendation/exception/RecommendationErrorCode.java
@@ -1,0 +1,16 @@
+package com.kjh.spacebook.domain.recommendation.exception;
+
+import com.kjh.spacebook.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum RecommendationErrorCode implements ErrorCode {
+    AI_PARSE_FAILED(HttpStatus.BAD_REQUEST, "검색 조건을 추출할 수 없습니다. 다시 입력해주세요."),
+    AI_API_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "AI 서비스에 일시적인 문제가 발생했습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/kjh/spacebook/domain/recommendation/service/GroqService.java
+++ b/src/main/java/com/kjh/spacebook/domain/recommendation/service/GroqService.java
@@ -1,0 +1,126 @@
+package com.kjh.spacebook.domain.recommendation.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kjh.spacebook.common.exception.BusinessException;
+import com.kjh.spacebook.domain.recommendation.exception.RecommendationErrorCode;
+import com.kjh.spacebook.domain.space.enums.SpaceType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GroqService {
+
+    @Value("${groq.api-key}")
+    private String apiKey;
+
+    private final ObjectMapper objectMapper;
+    private final RestTemplate restTemplate;
+
+    private static final String GROQ_URL = "https://api.groq.com/openai/v1/chat/completions";
+
+    private static final String PROMPT = """
+            사용자의 자연어 입력에서 공간 검색 조건을 추출해서 JSON으로 반환해.
+
+            추출할 필드:
+            - location: 위치/지역 (문자열, 없으면 null)
+            - capacity: 인원 수 (숫자, 없으면 null)
+            - spaceType: 공간 유형 (STUDY, PARTY, MEETING 중 하나, 없으면 null)
+              - 공부/스터디/독서 → STUDY
+              - 파티/모임/생일 → PARTY
+              - 회의/미팅/세미나 → MEETING
+
+            반드시 JSON만 반환해. 다른 텍스트는 절대 포함하지 마.
+
+            예시:
+            입력: "강남에서 3명이 미팅할 수 있는 곳"
+            출력: {"location":"강남","capacity":3,"spaceType":"MEETING"}
+
+            입력: "혼자 공부할 조용한 곳"
+            출력: {"location":null,"capacity":1,"spaceType":"STUDY"}
+
+            사용자 입력: "%s"
+            """;
+
+    public SearchCondition extractCondition(String query) {
+        try {
+            String prompt = String.format(PROMPT, query);
+
+            Map<String, Object> requestBody = Map.of(
+                    "model", "llama-3.3-70b-versatile",
+                    "messages", List.of(
+                            Map.of("role", "user", "content", prompt)
+                    ),
+                    "temperature", 0
+            );
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            headers.setBearerAuth(apiKey);
+
+            HttpEntity<Map<String, Object>> entity = new HttpEntity<>(requestBody, headers);
+
+            String response = restTemplate.postForObject(GROQ_URL, entity, String.class);
+
+            return parseResponse(response);
+        } catch (BusinessException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("Groq API 호출 실패: {}", e.getMessage());
+            throw new BusinessException(RecommendationErrorCode.AI_API_FAILED);
+        }
+    }
+
+    private SearchCondition parseResponse(String response) {
+        try {
+            JsonNode root = objectMapper.readTree(response);
+            String text = root
+                    .path("choices").get(0)
+                    .path("message")
+                    .path("content")
+                    .asText();
+
+            int start = text.indexOf("{");
+            int end = text.lastIndexOf("}");
+            String json = text.substring(start, end + 1);
+
+            JsonNode result = objectMapper.readTree(json);
+
+            String location = result.has("location") && !result.get("location").isNull()
+                    ? result.get("location").asText() : null;
+
+            Integer capacity = result.has("capacity") && !result.get("capacity").isNull()
+                    ? result.get("capacity").asInt() : null;
+
+            SpaceType spaceType = null;
+            if (result.has("spaceType") && !result.get("spaceType").isNull()) {
+                try {
+                    spaceType = SpaceType.valueOf(result.get("spaceType").asText());
+                } catch (IllegalArgumentException ignored) {
+                }
+            }
+
+            return new SearchCondition(location, capacity, spaceType);
+        } catch (Exception e) {
+            log.error("Groq 응답 파싱 실패: {}", e.getMessage());
+            throw new BusinessException(RecommendationErrorCode.AI_PARSE_FAILED);
+        }
+    }
+
+    public record SearchCondition(
+            String location,
+            Integer capacity,
+            SpaceType spaceType
+    ) {}
+}

--- a/src/main/java/com/kjh/spacebook/domain/recommendation/service/RecommendationService.java
+++ b/src/main/java/com/kjh/spacebook/domain/recommendation/service/RecommendationService.java
@@ -1,0 +1,32 @@
+package com.kjh.spacebook.domain.recommendation.service;
+
+import com.kjh.spacebook.domain.space.dto.response.SpaceListResponse;
+import com.kjh.spacebook.domain.space.entity.Space;
+import com.kjh.spacebook.domain.space.repository.SpaceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RecommendationService {
+    private final GroqService groqService;
+    private final SpaceRepository spaceRepository;
+
+    public List<SpaceListResponse> recommend(String query) {
+        GroqService.SearchCondition condition = groqService.extractCondition(query);
+
+        List<Space> spaces = spaceRepository.searchByConditions(
+                condition.location(),
+                condition.capacity(),
+                condition.spaceType()
+        );
+
+        return spaces.stream()
+                .map(SpaceListResponse::from)
+                .toList();
+    }
+}

--- a/src/main/java/com/kjh/spacebook/domain/space/repository/SpaceRepository.java
+++ b/src/main/java/com/kjh/spacebook/domain/space/repository/SpaceRepository.java
@@ -2,11 +2,15 @@ package com.kjh.spacebook.domain.space.repository;
 
 import com.kjh.spacebook.domain.space.entity.Space;
 import com.kjh.spacebook.domain.space.enums.SpaceStatus;
+import com.kjh.spacebook.domain.space.enums.SpaceType;
 import com.kjh.spacebook.domain.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface SpaceRepository extends JpaRepository<Space, Long> {
@@ -18,4 +22,18 @@ public interface SpaceRepository extends JpaRepository<Space, Long> {
     Optional<Space> findByIdAndDeletedAtIsNullAndSpaceStatus(Long id, SpaceStatus spaceStatus);
 
     Page<Space> findAllByOwnerAndDeletedAtIsNull(User owner, Pageable pageable);
+
+    @Query("""
+            SELECT s FROM Space s
+            WHERE s.deletedAt IS NULL
+            AND s.spaceStatus = com.kjh.spacebook.domain.space.enums.SpaceStatus.OPEN
+            AND (:location IS NULL OR s.location LIKE CONCAT('%', :location, '%'))
+            AND (:capacity IS NULL OR s.capacity >= :capacity)
+            AND (:spaceType IS NULL OR s.spaceType = :spaceType)
+            """)
+    List<Space> searchByConditions(
+            @Param("location") String location,
+            @Param("capacity") Integer capacity,
+            @Param("spaceType") SpaceType spaceType
+    );
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -22,3 +22,6 @@ jwt:
   secret: ${JWT_SECRET}
   access-token-expire-minutes: 30
   refresh-token-expire-days: 7
+
+groq:
+  api-key: ${GROQ_API_KEY}


### PR DESCRIPTION
## 연관된 이슈
- Closes #23

## 작업 내용
- AI 기반 공간 추천 API 구현 (`POST /api/v1/recommendations`)
- Groq API (LLaMA 3.3 70B) 연동하여 자연어에서 검색 조건 추출
- 추출된 조건(location, capacity, spaceType)으로 DB 검색
- RestTemplate Bean 등록
- SpaceRepository에 조건 검색 JPQL 쿼리 추가
- 인증된 사용자만 접근 가능

## 변경 파일
| 파일 | 변경 내용 |
|------|-----------|
| `RecommendationController.java` | AI 추천 엔드포인트 |
| `RecommendationService.java` | 추천 비즈니스 로직 (AI 조건 추출 → DB 검색) |
| `GroqService.java` | Groq API 연동 (프롬프트 → JSON 파싱) |
| `RecommendRequest.java` | 추천 요청 DTO |
| `RecommendationErrorCode.java` | 추천 관련 에러 코드 |
| `RestTemplateConfig.java` | RestTemplate Bean 등록 |
| `SpaceRepository.java` | `searchByConditions` JPQL 쿼리 추가 |
| `application.yaml` | Groq API 키 환경변수 바인딩 |

## 테스트 방법
```bash
# AI 추천
POST /api/v1/recommendations + {"query":"강남에서 3명이 미팅할 수 있는 곳"}  # 200 (공간 목록 반환)
POST /api/v1/recommendations + {"query":"홍대 파티룸"}                        # 200
POST /api/v1/recommendations + {"query":"10명 스터디"}                        # 200

# 비인증
POST /api/v1/recommendations (토큰 X)                                        # 401
```

## 기타 참고 사항
- Gemini API 무료 티어 폐지로 Groq API로 대체
- Groq API 키 7일 만료 (환경변수 `GROQ_API_KEY`)
- recommendation 패키지로 도메인 중심 네이밍