### PR TITLE
feat/space: 공간 목록 조회에 검색/필터/정렬 기능 추가 (add search, filter, sort and price range to space listing API)

### DIFF
--- a/src/main/java/com/kjh/spacebook/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/kjh/spacebook/common/exception/GlobalExceptionHandler.java
@@ -10,6 +10,8 @@ import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import jakarta.validation.ConstraintViolationException;
 
 @RestControllerAdvice
 @Slf4j
@@ -37,6 +39,18 @@ public class GlobalExceptionHandler {
                 .body(ApiResponse.error(message));
     }
 
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ApiResponse<?>> handleConstraintViolation(ConstraintViolationException ex) {
+        String message = ex.getConstraintViolations().stream()
+                .map(v -> v.getMessage())
+                .findFirst()
+                .orElse("잘못된 요청입니다.");
+
+        return ResponseEntity
+                .badRequest()
+                .body(ApiResponse.error(message));
+    }
+
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<ApiResponse<?>> handleInvalidJson(HttpMessageNotReadableException ex) {
         log.warn("invalid json request : ", ex);
@@ -51,6 +65,15 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(HttpStatus.FORBIDDEN)
                 .body(ApiResponse.error("해당 리소스에 접근할 권한이 없습니다."));
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ApiResponse<?>> handleTypeMismatch(MethodArgumentTypeMismatchException ex) {
+        String message = String.format("'%s' 값이 올바르지 않습니다.", ex.getValue());
+
+        return ResponseEntity
+                .badRequest()
+                .body(ApiResponse.error(message));
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/kjh/spacebook/common/security/SecurityConfig.java
+++ b/src/main/java/com/kjh/spacebook/common/security/SecurityConfig.java
@@ -9,6 +9,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.http.HttpMethod;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -52,6 +53,7 @@ public class SecurityConfig {
                                 "/webjars/**")
                         .permitAll()
                         .requestMatchers("/api/v1/auth/signup", "/api/v1/auth/login", "/api/v1/auth/reissue").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/spaces", "/api/v1/spaces/{spaceId}").permitAll()
                         .requestMatchers("/actuator/**").permitAll()
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers("/healthz").permitAll()

--- a/src/main/java/com/kjh/spacebook/domain/space/controller/SpaceController.java
+++ b/src/main/java/com/kjh/spacebook/domain/space/controller/SpaceController.java
@@ -7,6 +7,7 @@ import com.kjh.spacebook.domain.space.dto.response.SpaceListResponse;
 import com.kjh.spacebook.domain.space.dto.response.SpaceResponse;
 import com.kjh.spacebook.domain.space.service.SpaceService;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -14,7 +15,9 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import com.kjh.spacebook.domain.space.enums.SpaceType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -22,11 +25,14 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/spaces")
 @RequiredArgsConstructor
+@Validated
 public class SpaceController {
     private final SpaceService spaceService;
 
@@ -74,9 +80,13 @@ public class SpaceController {
 
     @GetMapping
     public ResponseEntity<ApiResponse<Page<SpaceListResponse>>> getSpaces(
-            @PageableDefault(size = 10) Pageable pageable
+            @RequestParam(required = false) String location,
+            @RequestParam(required = false) SpaceType spaceType,
+            @RequestParam(required = false) @Min(0) Integer minPrice,
+            @RequestParam(required = false) @Min(0) Integer maxPrice,
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
-        Page<SpaceListResponse> responses = spaceService.getSpaces(pageable);
+        Page<SpaceListResponse> responses = spaceService.getSpaces(location, spaceType, minPrice, maxPrice, pageable);
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(responses));
     }
 

--- a/src/main/java/com/kjh/spacebook/domain/space/exception/SpaceErrorCode.java
+++ b/src/main/java/com/kjh/spacebook/domain/space/exception/SpaceErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum SpaceErrorCode implements ErrorCode {
     SPACE_NOT_FOUND(HttpStatus.NOT_FOUND, "공간을 찾을 수 없습니다."),
-    SPACE_CLOSED(HttpStatus.BAD_REQUEST, "현재 대여가 불가능한 공간입니다.");
+    SPACE_CLOSED(HttpStatus.BAD_REQUEST, "현재 대여가 불가능한 공간입니다."),
+    INVALID_PRICE_RANGE(HttpStatus.BAD_REQUEST, "최소 가격이 최대 가격보다 클 수 없습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/kjh/spacebook/domain/space/repository/SpaceRepository.java
+++ b/src/main/java/com/kjh/spacebook/domain/space/repository/SpaceRepository.java
@@ -36,4 +36,21 @@ public interface SpaceRepository extends JpaRepository<Space, Long> {
             @Param("capacity") Integer capacity,
             @Param("spaceType") SpaceType spaceType
     );
+
+    @Query("""
+            SELECT s FROM Space s
+            WHERE s.deletedAt IS NULL
+            AND s.spaceStatus = com.kjh.spacebook.domain.space.enums.SpaceStatus.OPEN
+            AND (:location IS NULL OR s.location LIKE CONCAT('%', :location, '%'))
+            AND (:spaceType IS NULL OR s.spaceType = :spaceType)
+            AND (:minPrice IS NULL OR s.pricePerHour >= :minPrice)
+            AND (:maxPrice IS NULL OR s.pricePerHour <= :maxPrice)
+            """)
+    Page<Space> searchSpaces(
+            @Param("location") String location,
+            @Param("spaceType") SpaceType spaceType,
+            @Param("minPrice") Integer minPrice,
+            @Param("maxPrice") Integer maxPrice,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/kjh/spacebook/domain/space/service/SpaceService.java
+++ b/src/main/java/com/kjh/spacebook/domain/space/service/SpaceService.java
@@ -7,6 +7,7 @@ import com.kjh.spacebook.domain.space.dto.response.SpaceListResponse;
 import com.kjh.spacebook.domain.space.dto.response.SpaceResponse;
 import com.kjh.spacebook.domain.space.entity.Space;
 import com.kjh.spacebook.domain.space.enums.SpaceStatus;
+import com.kjh.spacebook.domain.space.enums.SpaceType;
 import com.kjh.spacebook.domain.space.exception.SpaceErrorCode;
 import com.kjh.spacebook.domain.space.repository.SpaceRepository;
 import com.kjh.spacebook.domain.user.entity.User;
@@ -81,8 +82,18 @@ public class SpaceService {
                 .map(SpaceListResponse::from);
     }
 
-    public Page<SpaceListResponse> getSpaces(Pageable pageable) {
-        return spaceRepository.findAllByDeletedAtIsNullAndSpaceStatus(SpaceStatus.OPEN, pageable)
+    public Page<SpaceListResponse> getSpaces(
+            String location,
+            SpaceType spaceType,
+            Integer minPrice,
+            Integer maxPrice,
+            Pageable pageable
+    ) {
+        if (minPrice != null && maxPrice != null && minPrice > maxPrice) {
+            throw new BusinessException(SpaceErrorCode.INVALID_PRICE_RANGE);
+        }
+
+        return spaceRepository.searchSpaces(location, spaceType, minPrice, maxPrice, pageable)
                 .map(SpaceListResponse::from);
     }
 


### PR DESCRIPTION
## 연관된 이슈
- Closes #27

## 작업 내용
- `GET /api/v1/spaces`에 검색/필터/정렬/가격 범위 기능 추가
  - `location`: 위치 검색 (LIKE 부분 일치)
  - `spaceType`: 공간 유형 필터 (STUDY, MEETING, PARTY 등)
  - `minPrice`, `maxPrice`: 가격 범위 필터
  - `sort`: 정렬 (기본값 createdAt DESC)
- JPQL 동적 검색 쿼리 (`IS NULL OR` 패턴)
- 입력 검증
  - `@Min(0)` + `@Validated`: 음수 가격 차단 (Bean Validation)
  - Service: 가격 범위 역전 검증 (`minPrice > maxPrice`)
- SecurityConfig: GET /api/v1/spaces, /api/v1/spaces/{spaceId} 비로그인 허용
- GlobalExceptionHandler 개선
  - `ConstraintViolationException` 핸들러 추가 (@RequestParam 검증)
  - `MethodArgumentTypeMismatchException` 핸들러 추가 (잘못된 enum 값)

## 변경 파일
| 파일 | 변경 내용 |
|------|-----------|
| `SpaceController.java` | 검색 파라미터, `@Validated`, `@Min(0)`, 기본 정렬 |
| `SpaceService.java` | 동적 검색 + 가격 범위 역전 검증 |
| `SpaceRepository.java` | `searchSpaces` JPQL 쿼리 추가 |
| `SpaceErrorCode.java` | `INVALID_PRICE_RANGE` 에러 코드 |
| `SecurityConfig.java` | GET spaces permitAll |
| `GlobalExceptionHandler.java` | 예외 핸들러 2개 추가 |

## 테스트 방법
```bash
# 성공 케이스
GET /api/v1/spaces                                          # 전체 목록 (최신순)
GET /api/v1/spaces?location=강남                             # 위치 검색
GET /api/v1/spaces?spaceType=STUDY                          # 유형 필터
GET /api/v1/spaces?sort=pricePerHour,asc                    # 가격 낮은순
GET /api/v1/spaces?minPrice=5000&maxPrice=20000             # 가격 범위
GET /api/v1/spaces?location=서울&spaceType=MEETING&minPrice=10000&maxPrice=20000&sort=pricePerHour,asc  # 복합

# 에러 케이스
GET /api/v1/spaces?minPrice=-1000                           # 400: 0 이상이어야 합니다
GET /api/v1/spaces?minPrice=30000&maxPrice=10000            # 400: 최소 가격이 최대 가격보다 클 수 없습니다.
GET /api/v1/spaces?spaceType=INVALID                        # 400: 'INVALID' 값이 올바르지 않습니다.
```

## 기타 참고 사항
- 정렬 필드 제한은 현재 단계에서 불필요하여 미적용 (프론트에서 버튼으로 제한)
- LIKE 검색 한계 (부분 일치만 지원) → 프론트 placeholder로 가이드
- 검증 계층 분리: Controller(@Min) = 형식 검증, Service = 비즈니스 규칙 검증