### PR TITLE
chore/deploy: Railway 배포용 DB 설정 수정 (replace localhost with Railway My…

### DIFF
--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -4,9 +4,9 @@ spring:
 
   datasource:
   #한글 깨짐 방지 및 타임존 문제 방지
-    url: jdbc:mysql://localhost:3306/${DB_NAME}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
-    username: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
+    url: jdbc:mysql://${MYSQLHOST}:${MYSQLPORT}/${MYSQLDATABASE}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: ${MYSQLUSER}
+    password: ${MYSQLPASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:


### PR DESCRIPTION
## 연관된 이슈
- Closes #56
- Closes #58
- Closes #59
- Closes #60

## 작업 내용
- Railway 배포를 위한 DB 환경변수 설정 — localhost 제거 및 환경변수 기반 전환
 (#56)
- Railway `MYSQL_URL` 형식 문제 해결 — 커스텀 `JDBC_URL` 환경변수로 전환 
(#58)
- Dockerfile 추가로 Java 17 빌드 환경 구성 
(#59)
- `server.port=${PORT:8080}` 설정 및 CRASHED 문제 해결
 (#60)

## 변경 파일

| 파일 | 변경 내용 |
|------|-----------|
| `backend/src/main/resources/application.yaml` | datasource를 `${JDBC_URL}` 기반으로 수정, `server.port=${PORT:8080}` 추가 |
| `backend/Dockerfile` | Java 17(eclipse-temurin:17-jdk) 기반 Docker 빌드/실행 환경 구성 |

## 테스트 방법
```bash
# 1. Railway 배포 로그에서 DB 연결 성공 확인
# HikariPool-1 - Start completed

# 2. Hibernate 테이블 자동 생성 확인
# create table users / spaces / reservations / refresh_tokens

# 3. 컨테이너 CRASHED 없이 정상 기동 유지 확인
# Railway Deploy 상태: SUCCESS
```

## 기타 참고 사항
- Railway의 `MYSQL_URL` 형식(`mysql://user:pass@host:port/db`)이 Spring JDBC 형식(`jdbc:mysql://host:port/db`)과 달라, Railway에 커스텀 변수 `JDBC_URL`을 추가하여 해결
- Railway 환경변수: `JDBC_URL`, `MYSQLUSER`, `MYSQLPASSWORD`, `JWT_SECRET`, `GROQ_API_KEY`
- Railway Builder를 Docker로 설정하여 Java 17 환경 명시