### PR TITLE
chore/deploy: 프론트엔드 Vercel 배포 (deploy frontend to Vercel)

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -13,7 +13,8 @@ import type {
   User,
 } from "@/types";
 
-const BASE_URL = "http://localhost:8080/api/v1";
+const BASE_URL =
+  process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080/api/v1";
 
 // localStorage에서 토큰 읽기/쓰기/삭제
 export function getAccessToken(): string | null {


### PR DESCRIPTION
## 연관된 이슈
- Closes #61

## 작업 내용
- 프론트엔드(Next.js)를 Vercel에 배포
- API BASE_URL을 환경변수(`NEXT_PUBLIC_API_URL`)로 변경하여 배포 환경에서 Railway 백엔드와 연동

## 변경 파일
| 파일 | 변경 내용 |
|------|-----------|
| `frontend/src/lib/api.ts` | BASE_URL을 `process.env.NEXT_PUBLIC_API_URL` 환경변수로 변경 (fallback: localhost:8080) |

## 테스트 방법
```bash
# Vercel 배포 URL에서 확인
# 1. 메인 페이지 접속
# 2. 공간 목록 조회
# 3. 로그인 (test@naver.com / test1234!!)
# 4. 예약, 마이페이지 등 전체 기능 확인
```

## 기타 참고 사항
- Vercel 환경변수: `NEXT_PUBLIC_API_URL=https://spacebook-production.up.railway.app/api/v1`
- 로컬 개발 시 환경변수 미설정이면 `http://localhost:8080/api/v1`로 fallback