### PR TITLE
feat/space: 공간 카드/상세 페이지 이미지 렌더링 추가 (render space images)

### DIFF
--- a/frontend/src/app/spaces/[id]/page.tsx
+++ b/frontend/src/app/spaces/[id]/page.tsx
@@ -71,8 +71,16 @@ export default function SpaceDetailPage() {
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
         {/* 공간 정보 */}
         <div className="lg:col-span-2 space-y-6">
-          <div className="h-64 bg-muted rounded-lg flex items-center justify-center text-muted-foreground">
-            {space.spaceName} 이미지
+          <div className="h-64 bg-muted rounded-lg flex items-center justify-center text-muted-foreground overflow-hidden">
+            {space.imageUrl ? (
+              <img
+                src={space.imageUrl}
+                alt={space.spaceName}
+                className="w-full h-full object-cover rounded-lg"
+              />
+            ) : (
+              `${space.spaceName} 이미지`
+            )}
           </div>
 
           <div>

--- a/frontend/src/components/spaces/space-card.tsx
+++ b/frontend/src/components/spaces/space-card.tsx
@@ -17,8 +17,16 @@ interface SpaceCardProps {
 export default function SpaceCard({ space }: SpaceCardProps) {
   return (
     <Card className="overflow-hidden">
-      <div className="h-48 bg-muted flex items-center justify-center text-muted-foreground text-sm">
-        {space.imageUrl ? space.spaceName : "이미지 없음"}
+      <div className="h-48 bg-muted flex items-center justify-center text-muted-foreground text-sm overflow-hidden">
+        {space.imageUrl ? (
+          <img
+            src={space.imageUrl}
+            alt={space.spaceName}
+            className="w-full h-full object-cover"
+          />
+        ) : (
+          "이미지 없음"
+        )}
       </div>
 
       <CardContent className="pt-4 space-y-2">


### PR DESCRIPTION
## 연관된 이슈
- Closes #64

## 작업 내용
- 공간 카드 및 상세 페이지에서 실제 이미지를 렌더링하도록 수정
- 기존: imageUrl이 있어도 텍스트만 표시
- 변경: `<img>` 태그로 실제 이미지 렌더링, 없으면 "이미지 없음" 표시

## 변경 파일
| 파일 | 변경 내용 |
|------|-----------|
| `frontend/src/components/spaces/space-card.tsx` | imageUrl 존재 시 `<img>` 태그로 이미지 렌더링 |
| `frontend/src/app/spaces/[id]/page.tsx` | 상세 페이지에서도 동일하게 이미지 렌더링 |

## 테스트 방법
```bash
# 메인 페이지에서 공간 카드 이미지 확인
# 공간 상세 페이지에서 이미지 확인
# imageUrl 없는 공간은 "이미지 없음" 표시 확인
```

## 기타 참고 사항
- Railway DB에 Unsplash 무료 이미지 URL로 공간 데이터 업데이트 완료