### PR TITLE
fix/swagger: Swagger 서버 URL HTTPS 명시로 Mixed Content 에러 해결 (fix Mixed Content error by specifying HTTPS server URL)

### DIFF
--- a/backend/src/main/java/com/kjh/spacebook/common/config/OpenApiConfig.java
+++ b/backend/src/main/java/com/kjh/spacebook/common/config/OpenApiConfig.java
@@ -5,8 +5,11 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
 
 @Configuration
 public class OpenApiConfig {
@@ -16,6 +19,11 @@ public class OpenApiConfig {
         String securitySchemeName = "Bearer Authentication";
 
         return new OpenAPI()
+                .servers(List.of(
+                        new Server().url("https://spacebook-production.up.railway.app")
+                                .description("운영 서버"),
+                        new Server().url("http://localhost:8080")
+                                .description("로컬 서버")))
                 .info(new Info()
                         .title("SpaceBook API")
                         .description("AI 기반 공간 예약 플랫폼 API 문서")


### PR DESCRIPTION
## 연관된 이슈
- Closes #70

## 작업 내용
- Swagger UI에서 Execute 시 Mixed Content 에러로 실제 응답이 표시되지 않는 문제 수정
- OpenApiConfig에 HTTPS 서버 URL을 명시적으로 지정

## 변경 파일

| 파일 | 변경 내용 |
|------|-----------|
| `common/config/OpenApiConfig.java` | servers 설정 추가 (운영: HTTPS, 로컬: HTTP) |

## 테스트 방법

```bash
# 배포 후 Swagger UI 접속
# https://spacebook-production.up.railway.app/swagger-ui.html

# 1. 공간 목록 조회 (GET /api/v1/spaces) → Try it out → Execute
# 2. Response Body에 실제 서버 응답 JSON이 표시되는지 확인
# 3. Request URL이 https://로 시작하는지 확인
```

## 기타 참고 사항
- 원인: springdoc이 Railway 내부에서 HTTP로 서버 URL을 자동 감지 → 브라우저가 HTTPS 페이지에서 HTTP 요청 차단 (Mixed Content)
- 로컬 서버(http://localhost:8080)도 서버 목록에 추가하여 로컬 테스트 가능