### PR TITLE
fix/swagger: Swagger Pageable @ParameterObject 추가로 파라미터 표시 수정 (fix Pageable parameter display)

### DIFF
--- a/backend/src/main/java/com/kjh/spacebook/domain/reservation/controller/ReservationController.java
+++ b/backend/src/main/java/com/kjh/spacebook/domain/reservation/controller/ReservationController.java
@@ -8,6 +8,7 @@ import com.kjh.spacebook.domain.reservation.service.ReservationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springdoc.core.annotations.ParameterObject;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -45,7 +46,7 @@ public class ReservationController {
     @GetMapping("/my")
     public ResponseEntity<ApiResponse<Page<ReservationListResponse>>> getMyReservations(
             @Parameter(hidden = true) @AuthenticationPrincipal Long userId,
-            @PageableDefault(size = 10) Pageable pageable
+            @ParameterObject @PageableDefault(size = 10) Pageable pageable
     ) {
         Page<ReservationListResponse> responses = reservationService.getMyReservations(userId, pageable);
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(responses));

--- a/backend/src/main/java/com/kjh/spacebook/domain/space/controller/SpaceController.java
+++ b/backend/src/main/java/com/kjh/spacebook/domain/space/controller/SpaceController.java
@@ -11,6 +11,7 @@ import com.kjh.spacebook.domain.reservation.service.ReservationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springdoc.core.annotations.ParameterObject;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
@@ -84,7 +85,7 @@ public class SpaceController {
     @GetMapping("/me")
     public ResponseEntity<ApiResponse<Page<SpaceListResponse>>> getMySpaces(
             @Parameter(hidden = true) @AuthenticationPrincipal Long userId,
-            @PageableDefault(size = 10) Pageable pageable
+            @ParameterObject @PageableDefault(size = 10) Pageable pageable
     ) {
         Page<SpaceListResponse> responses = spaceService.getMySpaces(userId, pageable);
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(responses));
@@ -104,7 +105,7 @@ public class SpaceController {
             @RequestParam(name = "minPrice", required = false) @Min(0) Integer minPrice,
             @Parameter(description = "최대 가격", example = "50000")
             @RequestParam(name = "maxPrice", required = false) @Min(0) Integer maxPrice,
-            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+            @ParameterObject @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
         Page<SpaceListResponse> responses = spaceService.getSpaces(location, spaceType, minPrice, maxPrice, pageable);
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(responses));


### PR DESCRIPTION
## 연관된 이슈
- Closes #72

## 작업 내용
- Pageable 파라미터에 `@ParameterObject` 추가하여 Swagger UI에서 page, size, sort가 개별 파라미터로 표시되도록 수정

## 변경 파일

| 파일 | 변경 내용 |
|------|-----------|
| `space/controller/SpaceController.java` | getMySpaces, getSpaces의 Pageable에 @ParameterObject 추가 |
| `reservation/controller/ReservationController.java` | getMyReservations의 Pageable에 @ParameterObject 추가 |

## 테스트 방법

```bash
# Swagger UI 접속 (강력 새로고침: Ctrl+Shift+R)
# https://spacebook-production.up.railway.app/swagger-ui.html

# 1. GET /api/v1/spaces → Try it out → Execute
# 2. page, size, sort가 개별 파라미터로 표시되는지 확인
# 3. 기본값으로 Execute 시 정상 응답 확인
```

## 기타 참고 사항
- 기존: Pageable이 required 복합 객체로 표시, 기본값 page=1073741824 → 500 에러
- 수정: @ParameterObject로 page, size, sort 개별 파라미터 표시, 정상 기본값 적용