### PR TITLE
feat/email-notification: 예약 생성/취소 시 이메일 알림 발송 (add email notification on reservation create/cancel)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ AI 기반 공간 예약 플랫폼
 | Validation | Bean Validation (Hibernate Validator) |
 | AI | Groq API (LLaMA 3.3 70B) |
 | API Docs | springdoc-openapi (Swagger UI) |
+| Email | Spring Boot Mail (Gmail SMTP) |
 | Test | JUnit 5 + Mockito |
 | Deploy | Railway (Docker) |
 
@@ -86,13 +87,14 @@ AI 기반 공간 예약 플랫폼
 │  │                       Service Layer                         │    │
 │  │  AuthService · SpaceService · ReservationService            │    │
 │  │  UserService · RecommendationService · GroqService          │    │
+│  │  EmailService (@Async)                                      │    │
 │  └───────┬──────────────────────────────────────┬──────────────┘    │
 │          │ 비즈니스 규칙 검증                       │                 │
 │          ▼                                       ▼                  │
-│  ┌────────────────────┐              ┌──────────────────────┐       │
-│  │  Repository Layer  │              │   Groq API (외부)    │       │
-│  │  (Spring Data JPA) │              │   LLaMA 3.3 70B      │       │
-│  └────────┬───────────┘              └──────────────────────┘       │
+│  ┌────────────────────┐    ┌──────────────────────┐  ┌───────────┐  │
+│  │  Repository Layer  │    │   Groq API (외부)    │  │Gmail SMTP │  │
+│  │  (Spring Data JPA) │    │   LLaMA 3.3 70B      │  │  (메일)   │  │
+│  └────────┬───────────┘    └──────────────────────┘  └───────────┘  │
 │           │                                                         │
 └───────────┼─────────────────────────────────────────────────────────┘
             │
@@ -117,6 +119,7 @@ spacebook/
 │       │   ├── config/               # Security, OpenAPI, RestTemplate, PasswordEncoder
 │       │   ├── exception/            # GlobalExceptionHandler, ErrorCode, BusinessException
 │       │   ├── response/             # ApiResponse 공통 응답 래퍼
+│       │   ├── service/              # EmailService (이메일 알림)
 │       │   └── security/jwt/         # JwtUtil, JwtAuthenticationFilter, JwtProperties
 │       └── domain/
 │           ├── auth/                 # 회원가입, 로그인, 로그아웃, 탈퇴, 토큰 재발급
@@ -165,6 +168,7 @@ spacebook/
 - 날짜별 예약된 시간대 조회 API → 프론트엔드에서 시각적 표시
 - 예약 취소 (시작 1일 전까지)
 - 총 가격 자동 계산 (시간 × 시간당 가격)
+- 예약 생성/취소 시 이메일 알림 발송 (`@Async` 비동기 처리)
 
 ### 4. AI 공간 추천
 
@@ -1063,6 +1067,8 @@ JUnit 5 + Mockito 기반 서비스 레이어 단위 테스트 **26개**
 | `MYSQLPASSWORD` | DB 비밀번호 |
 | `JWT_SECRET` | JWT 서명 키 |
 | `GROQ_API_KEY` | Groq API 키 |
+| `MAIL_USERNAME` | 발송용 Gmail 주소 |
+| `MAIL_PASSWORD` | Gmail 앱 비밀번호 (16자리) |
 | `NEXT_PUBLIC_API_URL` | 백엔드 API URL (프론트엔드) |
 
 ### Backend
@@ -1087,5 +1093,6 @@ npm run dev
 ## 향후 계획
 
 - 관리자 공간 관리 페이지 (현재 API만 구현, 프론트엔드 관리자 페이지 미구현)
-- 이메일 인증 기능
+- S3 이미지 업로드 적용 (현재 대표 이미지 URL 1개 → 다중 이미지 업로드/조회)
+- 공간 리뷰/별점 기능
 - 테스트 커버리지 확대 (컨트롤러 통합 테스트, 리포지토리 테스트)

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -30,6 +30,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 
 	// JWT
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'

--- a/backend/src/main/java/com/kjh/spacebook/SpacebookApplication.java
+++ b/backend/src/main/java/com/kjh/spacebook/SpacebookApplication.java
@@ -3,9 +3,11 @@ package com.kjh.spacebook;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
 @ConfigurationPropertiesScan
+@EnableAsync
 public class SpacebookApplication {
 
 	public static void main(String[] args) {

--- a/backend/src/main/java/com/kjh/spacebook/domain/reservation/service/ReservationService.java
+++ b/backend/src/main/java/com/kjh/spacebook/domain/reservation/service/ReservationService.java
@@ -1,6 +1,7 @@
 package com.kjh.spacebook.domain.reservation.service;
 
 import com.kjh.spacebook.common.exception.BusinessException;
+import com.kjh.spacebook.common.service.EmailService;
 import com.kjh.spacebook.domain.reservation.dto.request.CreateReservationRequest;
 import com.kjh.spacebook.domain.reservation.dto.response.ReservationListResponse;
 import com.kjh.spacebook.domain.reservation.dto.response.ReservationResponse;
@@ -35,6 +36,7 @@ public class ReservationService {
     private final ReservationRepository reservationRepository;
     private final SpaceRepository spaceRepository;
     private final UserRepository userRepository;
+    private final EmailService emailService;
 
     @Transactional
     public ReservationResponse createReservation(
@@ -89,6 +91,7 @@ public class ReservationService {
         );
 
         reservationRepository.save(reservation);
+        emailService.sendReservationConfirm(user.getEmail(), reservation);
 
         return ReservationResponse.from(reservation);
     }
@@ -147,5 +150,6 @@ public class ReservationService {
         }
 
         reservation.cancel();
+        emailService.sendReservationCancel(reservation.getUser().getEmail(), reservation);
     }
 }

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -8,6 +8,18 @@ spring:
     password: ${MYSQLPASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+
   jpa:
     hibernate:
       ddl-auto: update


### PR DESCRIPTION
## 연관된 이슈
Closes #76

## 작업 내용
- 예약 생성/취소 시 사용자 이메일로 알림 메일 발송
- Gmail SMTP + `@Async` 비동기 처리
- 발신자명 SpaceBook 표시

## 변경 파일

| 파일 | 변경 내용 |
|------|-----------|
| `build.gradle` | `spring-boot-starter-mail` 의존성 추가 |
| `application.yaml` | Gmail SMTP 설정 (`MAIL_USERNAME`, `MAIL_PASSWORD` 환경변수) |
| `SpacebookApplication.java` | `@EnableAsync` 추가 |
| `EmailService.java` (신규) | 예약 확정/취소 이메일 발송 서비스 |
| `ReservationService.java` | 생성/취소 시 `EmailService` 호출 추가 |
| `README.md` | 기술 스택, 아키텍처, 주요 기능, 환경변수, 향후 계획 업데이트 |

## 테스트 방법

```bash
# 회원가입
curl -X POST http://localhost:8080/api/v1/auth/signup \
  -H "Content-Type: application/json" \
  -d "{\"username\":\"test\",\"email\":\"test@example.com\",\"password\":\"test1234!!\",\"phoneNumber\":\"010-1234-5678\"}"

# 예약 생성 → 확정 메일 수신 확인
curl -X POST http://localhost:8080/api/v1/reservations \
  -H "Authorization: Bearer {token}" \
  -H "Content-Type: application/json" \
  -d "{\"spaceId\":1,\"startTime\":\"2026-03-01T10:00:00\",\"endTime\":\"2026-03-01T12:00:00\",\"peopleCount\":5}"

# 예약 취소 → 취소 메일 수신 확인
curl -X PATCH http://localhost:8080/api/v1/reservations/{id}/cancel \
  -H "Authorization: Bearer {token}"
```

## 기타 참고 사항
- `@Async` 비동기 처리로 이메일 발송이 API 응답 속도에 영향 없음
- 이메일 발송 실패 시 로그만 남기고 예약 처리는 정상 진행 (try-catch)
- 환경변수 `MAIL_USERNAME`, `MAIL_PASSWORD` 미설정 시 서버 기동 실패하므로 Railway에도 설정 필요