### PR TITLE
fix/email-notification: SMTP → SendGrid HTTP API 전환 (switch email from SMTP to SendGrid HTTP API)

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -30,7 +30,6 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.boot:spring-boot-starter-mail'
 
 	// JWT
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -8,18 +8,6 @@ spring:
     password: ${MYSQLPASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
-  mail:
-    host: smtp.gmail.com
-    port: 465
-    username: ${MAIL_USERNAME}
-    password: ${MAIL_PASSWORD}
-    properties:
-      mail:
-        smtp:
-          auth: true
-          ssl:
-            enable: true
-
   jpa:
     hibernate:
       ddl-auto: update
@@ -39,6 +27,10 @@ jwt:
 
 groq:
   api-key: ${GROQ_API_KEY}
+
+sendgrid:
+  api-key: ${SENDGRID_API_KEY}
+  from-email: lsa68803@naver.com
 
 springdoc:
   swagger-ui:


### PR DESCRIPTION
## 연관된 이슈
- Closes #82

## 작업 내용
- Railway SMTP 아웃바운드 차단으로 이메일 발송 불가 → SendGrid HTTP API로 전환
- `spring-boot-starter-mail` 의존성 제거, `EmailService`를 RestTemplate 기반으로 재작성
- 예약 생성/취소 시 이메일 알림 정상 발송 확인

## 변경 파일

| 파일 | 변경 내용 |
|------|-----------|
| `backend/build.gradle` | `spring-boot-starter-mail` 의존성 제거 |
| `backend/src/main/resources/application.yaml` | `spring.mail.*` 제거, `sendgrid.api-key`, `sendgrid.from-email` 추가 |
| `backend/src/main/java/com/kjh/spacebook/common/service/EmailService.java` | JavaMailSender → RestTemplate + SendGrid HTTP API 전환 |

## 테스트 방법

```bash
# 로그인 (lsa68803@naver.com)
curl -X POST http://localhost:8081/api/v1/auth/login \
  -H "Content-Type: application/json" \
  -d '{"email":"lsa68803@naver.com","password":"test1234!!"}'

# 예약 생성 → 확정 이메일 수신 확인
curl -X POST http://localhost:8081/api/v1/reservations \
  -H "Authorization: Bearer {token}" \
  -H "Content-Type: application/json" \
  -d '{"spaceId":1,"startTime":"2026-03-02T10:00:00","endTime":"2026-03-02T12:00:00","peopleCount":2,"purpose":"test"}'

# 예약 취소 → 취소 이메일 수신 확인
curl -X PATCH http://localhost:8081/api/v1/reservations/{id}/cancel \
  -H "Authorization: Bearer {token}"
```

## 기타 참고 사항
- Railway 환경변수에 `SENDGRID_API_KEY` 추가 필요
- SendGrid 무료 플랜: 100통/일
- 발신자: `lsa68803@naver.com` (Single Sender Verification 완료)